### PR TITLE
[Solitea] Fix incorrect evaluation of IsNull expression

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/AggregationPropertyContainer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/AggregationPropertyContainer.cs
@@ -154,6 +154,11 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("IsNull"), property.NullCheck));
             }
 
+            if (property.RawValue != null)
+            {
+                memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("RawValue"), property.RawValue));
+            }
+
             return Expression.MemberInit(Expression.New(namedPropertyType), memberBindings);
         }
     }

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/NamedPropertyExpression.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/NamedPropertyExpression.cs
@@ -34,6 +34,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
         // and use Value only if IsNull is false.
         public Expression NullCheck { get; set; }
 
+        public Expression RawValue { get; set; }
+
         public int? PageSize { get; set; }
 
         public bool AutoSelected { get; set; }

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/PropertyContainer.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/PropertyContainer.cs
@@ -137,6 +137,11 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("IsNull"), property.NullCheck));
             }
 
+            if (property.RawValue != null)
+            {
+                memberBindings.Add(Expression.Bind(namedPropertyType.GetProperty("RawValue"), property.RawValue));
+            }
+
             return Expression.MemberInit(Expression.New(namedPropertyType), memberBindings);
         }
 
@@ -208,11 +213,14 @@ namespace Microsoft.AspNet.OData.Query.Expressions
 
         private class SingleExpandedProperty<T> : NamedProperty<T>
         {
+
+            public object RawValue { get; set; }
+
             public bool IsNull { get; set; }
 
             public override object GetValue()
             {
-                return IsNull ? (object)null : Value;
+                return IsNull ? (object)null : (RawValue == null ? (object)null : Value);
             }
         }
 

--- a/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/Expressions/SelectExpandBinder.cs
@@ -505,6 +505,8 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                 Expression propertyName = CreatePropertyNameExpression(elementType, propertyToExpand, source);
                 Expression propertyValue = CreatePropertyValueExpressionWithFilter(elementType, propertyToExpand, source,
                     expandItem);
+
+                Expression rawPropertyValue = propertyValue;
                 Expression nullCheck = GetNullCheckExpression(propertyToExpand, propertyValue, projection);
 
                 Expression countExpression = CreateTotalCountExpression(propertyValue, expandItem);
@@ -522,6 +524,7 @@ namespace Microsoft.AspNet.OData.Query.Expressions
                     if (!propertyToExpand.Type.IsCollection())
                     {
                         propertyExpression.NullCheck = nullCheck;
+                        propertyExpression.RawValue = rawPropertyValue;
                     }
                     else if (_settings.PageSize.HasValue)
                     {

--- a/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/PropertyContainerTest.cs
+++ b/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/Query/Expressions/PropertyContainerTest.cs
@@ -82,8 +82,9 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
             int propertyValue = 42;
             Expression propertyNameExpression = Expression.Constant(propertyName);
             Expression propertyValueExpression = Expression.Constant(propertyValue);
+            Expression rawPropertyValueExpression = Expression.Constant(propertyValue);
             Expression nullCheckExpression = Expression.Constant(false);
-            var properties = new[] { new NamedPropertyExpression(propertyNameExpression, propertyValueExpression) { NullCheck = nullCheckExpression } };
+            var properties = new[] { new NamedPropertyExpression(propertyNameExpression, propertyValueExpression) { NullCheck = nullCheckExpression, RawValue = rawPropertyValueExpression } };
 
             // Act
             Expression containerExpression = PropertyContainer.CreatePropertyContainer(properties);
@@ -96,13 +97,36 @@ namespace Microsoft.AspNet.OData.Test.Query.Expressions
         }
 
         [Fact]
+        public void CreatePropertyContainer_WithNullCheckFalseAndNullProperty_PropertyIsNull()
+        {
+            // Arrange
+            string propertyName = "PropertyName";
+            object propertyValue = 42;
+            object rawPropertyValue = null;
+            Expression propertyNameExpression = Expression.Constant(propertyName);
+            Expression propertyValueExpression = Expression.Constant(propertyValue);
+            Expression rawPropertyValueExpression = Expression.Constant(rawPropertyValue);
+            Expression nullCheckExpression = Expression.Constant(false);
+            var properties = new[] { new NamedPropertyExpression(propertyNameExpression, propertyValueExpression) { NullCheck = nullCheckExpression, RawValue = rawPropertyValueExpression } };
+
+            // Act
+            Expression containerExpression = PropertyContainer.CreatePropertyContainer(properties);
+
+            // Assert
+            PropertyContainer container = ToContainer(containerExpression);
+            var dict = container.ToDictionary(new IdentityPropertyMapper());
+            Assert.Contains(propertyName, dict.Keys);
+            Assert.Null(dict[propertyName]);
+        }
+
+        [Fact]
         public void CreatePropertyContainer_MultiplePropertiesWithNullCheck()
         {
             // Arrange
             var properties = new[] 
             { 
                 new NamedPropertyExpression(name: Expression.Constant("Prop1"), value: Expression.Constant(1)) { NullCheck = Expression.Constant(true) },
-                new NamedPropertyExpression(name: Expression.Constant("Prop2"), value: Expression.Constant(2)) { NullCheck = Expression.Constant(false) },
+                new NamedPropertyExpression(name: Expression.Constant("Prop2"), value: Expression.Constant(2)) { NullCheck = Expression.Constant(false), RawValue = Expression.Constant(2) },
             };
 
             // Act


### PR DESCRIPTION
The problem: when multiple keys with shadow property is used, NullCheck expression is incorrectly evaluated.
This causes null value to be incorrectly recognized as actual object and referencing parameters of this object
fails.

The solution: we have introduced new property RawValue which holds actual object referenced by navigation property
we use it to double check if the property is null.
